### PR TITLE
Fix tiled image dimensions to resemble ZCYX

### DIFF
--- a/instanseg/instanseg.py
+++ b/instanseg/instanseg.py
@@ -442,7 +442,6 @@ class InstanSeg():
         
         if normalise:
             image = percentile_normalize(image, subsampling_factor=normalisation_subsampling_factor)
-            image = image
 
         output_dimension = 2 if self.instanseg.cells_and_nuclei else 1
 
@@ -471,6 +470,7 @@ class InstanSeg():
             instances = interpolate(instances, size=original_shape[-2:], mode="nearest")
 
             if return_image_tensor:
+                image = image[None]
                 image = interpolate(image, size=original_shape[-2:], mode="bilinear")
 
         if return_image_tensor:

--- a/instanseg/utils/utils.py
+++ b/instanseg/utils/utils.py
@@ -321,7 +321,7 @@ def percentile_normalize(img: Union[np.ndarray, torch.Tensor], percentile=0.1, s
         img = _move_channel_axis(img, to_back=True)
         for c in range(img.shape[-1]):
             im_temp = img[::subsampling_factor, ::subsampling_factor, c]
-            (p_min, p_max) = torch.quantile(im_temp, torch.tensor([percentile / 100, (100 - percentile) / 100],device = im_temp.device))
+            (p_min, p_max) = np.percentile(im_temp.cpu(), [percentile, 100 - percentile])
             img[:, :, c] = (img[:, :, c] - p_min) / max(epsilon, p_max - p_min)
        # img = img / np.maximum(0.01, torch.max(img))
         return img.movedim(2, channel_axis)

--- a/instanseg/utils/utils.py
+++ b/instanseg/utils/utils.py
@@ -321,7 +321,7 @@ def percentile_normalize(img: Union[np.ndarray, torch.Tensor], percentile=0.1, s
         img = _move_channel_axis(img, to_back=True)
         for c in range(img.shape[-1]):
             im_temp = img[::subsampling_factor, ::subsampling_factor, c]
-            (p_min, p_max) = np.percentile(im_temp.cpu(), [percentile, 100 - percentile])
+            (p_min, p_max) = torch.quantile(im_temp, torch.tensor([percentile / 100, (100 - percentile) / 100],device = im_temp.device))
             img[:, :, c] = (img[:, :, c] - p_min) / max(epsilon, p_max - p_min)
        # img = img / np.maximum(0.01, torch.max(img))
         return img.movedim(2, channel_axis)


### PR DESCRIPTION
As described in https://github.com/instanseg/instanseg/issues/32

<details>
First of all, thank you for this fantastic tool, it has been a lot of fun playing around with this!

We were trying to use the sliding window inference function to analyze larger images, and it seems that the process runs into problem when it wants to interpolate the image to its original shape, since it is lacking a dimension (instanseg.py line 474):
```Python
if return_image_tensor:
  image = interpolate(image, size=original_shape[-2:], mode="bilinear")
```
There, images should have the shape ZCYX, but the image passed on is of dimensions CYX, which cannot be handled by `torch.nn.functional.interpolate()`.

By simply adding `image = image[None]` (which is also used in the `.eval_small_image()`) right before that line, the interpolation does not fail:
```Python
if return_image_tensor:
  image = image[None]
  image = interpolate(image, size=original_shape[-2:], mode="bilinear")
```

Then, the `image = image` on line 445 can be omitted as well :)
</details>