### PR TITLE
Enable version specification

### DIFF
--- a/instanseg/utils/create_bioimageio_model.py
+++ b/instanseg/utils/create_bioimageio_model.py
@@ -94,7 +94,7 @@ def readme(model_name: str, model_dict: dict = None):
           #  f.write(str(model_dict["source_dataset"]))
 
 
-def modify_yaml_for_qupath_config(yaml_path, pixel_size: float, dim_in: int = 3, dim_out: int = 2):
+def modify_yaml_for_qupath_config(yaml_path, pixel_size: float, dim_in: int = 3, dim_out: int = 2, version: str = None):
 
     #copy ijm files
     import shutil
@@ -113,41 +113,42 @@ def modify_yaml_for_qupath_config(yaml_path, pixel_size: float, dim_in: int = 3,
         ]}
 
     data['config']['deepimagej'] = {
-    'allow_tiling': True,
-    'model_keys': None,
-    'prediction': {
-        'preprocess': [
-            {'kwargs': 'instanseg_preprocess.ijm'}
-        ],
-        'postprocess': [
-            {'kwargs': 'instanseg_postprocess.ijm'}
-        ]
-    },
-    'pyramidal_model': False,
-    'test_information': {
-        'inputs': [
-            {
-                'name': 'test-input.npy',
-                'pixel_size': {
-                    'x': 1.0,
-                    'y': 1.0,
-                    'z': 1.0
-                },
-                'size': f'256 x 256 x 1 x {dim_in}'
-            }
-        ],
-        'memory_peak': None,
-        'outputs': [
-            {
-                'name': 'test-output.npy',
-                'size': f'256 x 256 x 1 x {dim_out}',
-                'type': 'image'
-            }
-        ],
-        'runtime': None
+        'allow_tiling': True,
+        'model_keys': None,
+        'prediction': {
+            'preprocess': [
+                {'kwargs': 'instanseg_preprocess.ijm'}
+            ],
+            'postprocess': [
+                {'kwargs': 'instanseg_postprocess.ijm'}
+            ]
+        },
+        'pyramidal_model': False,
+        'test_information': {
+            'inputs': [
+                {
+                    'name': 'test-input.npy',
+                    'pixel_size': {
+                        'x': 1.0,
+                        'y': 1.0,
+                        'z': 1.0
+                    },
+                    'size': f'256 x 256 x 1 x {dim_in}'
+                }
+            ],
+            'memory_peak': None,
+            'outputs': [
+                {
+                    'name': 'test-output.npy',
+                    'size': f'256 x 256 x 1 x {dim_out}',
+                    'type': 'image'
+                }
+            ],
+            'runtime': None
+        }
     }
-
-    }
+    if version is not None:
+        data["version"] = version
 
     with open(yaml_path, 'w') as file:
         yaml.dump(data, file)
@@ -168,7 +169,8 @@ def export_bioimageio(torchsript: torch.jit._script.RecursiveScriptModule,
                       model_name: str, 
                       test_img_path: str, 
                       model_dict: dict = None, 
-                      output_name = None):
+                      output_name = None,
+                      version: str = None):
     
     set_export_paths()
 
@@ -353,7 +355,7 @@ def export_bioimageio(torchsript: torch.jit._script.RecursiveScriptModule,
         zip_ref.extractall(destination)
     
     yaml_path = os.path.join(destination, 'rdf.yaml')
-    modify_yaml_for_qupath_config(yaml_path, pixel_size=model_pixel_size, dim_in=dim_in, dim_out=dim_out)
+    modify_yaml_for_qupath_config(yaml_path, pixel_size=model_pixel_size, dim_in=dim_in, dim_out=dim_out, version=version)
 
     
     make_archive(destination, input)


### PR DESCRIPTION
Enable specifying a semantic version in a bioimageio model rdf.yaml. Previously, it was impossible to specify versions in the model specification, and this version of the bioimageio.core model doesn't allow you to specify version through a named arg nor via kwargs, so we must modify the yaml afterwards.