### PR TITLE
Remove AICSImageIO and add bioio

### DIFF
--- a/instanseg/inference_class.py
+++ b/instanseg/inference_class.py
@@ -148,16 +148,6 @@ class InstanSeg():
                 image_array = slide.get_image_data().squeeze()
             else:
                 return image_str, img_pixel_size
-
-        elif self.prefered_image_reader == "AICSImageIO":
-            from aicsimageio import AICSImage
-            slide = AICSImage(image_str)
-            img_pixel_size = slide.physical_pixel_sizes.X
-            num_pixels = np.cumprod(slide.shape)[-1]
-            if num_pixels < self.medium_image_threshold:
-                image_array = slide.get_image_data().squeeze()
-            else:
-                return image_str, img_pixel_size
         else:
             raise NotImplementedError(f"Image reader {self.prefered_image_reader} is not implemented.")
         
@@ -182,16 +172,6 @@ class InstanSeg():
             from tiffslide import TiffSlide
             slide = TiffSlide(image_str)
             img_pixel_size = slide.properties['tiffslide.mpp-x']
-            if img_pixel_size is not None and img_pixel_size > 0 and img_pixel_size < 2:
-                return img_pixel_size
-        except Exception as e:
-            print(e)
-            pass
-        from aicsimageio import AICSImage 
-        try:
-            
-            slide = AICSImage(image_str)
-            img_pixel_size = slide.physical_pixel_sizes.X
             if img_pixel_size is not None and img_pixel_size > 0 and img_pixel_size < 2:
                 return img_pixel_size
         except Exception as e:
@@ -563,7 +543,7 @@ class InstanSeg():
             """
             Evaluate a whole slide input image using the InstanSeg model. This function uses slideio to read an image and then segments it using the instanseg model. The segmentation is done in a tiled manner to avoid memory issues. 
             
-            :param image:: The input image to be evaluated.
+            :param image: The input image to be evaluated.
             :param pixel_size: The pixel size of the image, in microns. If not provided, it will be read from the image metadata.
             :param normalise: Controls whether the image is normalised.
             :param tile_size: The width/height of the tiles that the image will be split into.

--- a/instanseg/utils/create_bioimageio_model.py
+++ b/instanseg/utils/create_bioimageio_model.py
@@ -2,7 +2,7 @@ import os
 import bioimageio.core
 import numpy as np
 import torch
-from aicsimageio import AICSImage
+from bioio import BioImage
 
 from instanseg.utils.augmentations import Augmentations
 from instanseg.utils.utils import _choose_device, show_images
@@ -190,7 +190,7 @@ def export_bioimageio(torchsript: torch.jit._script.RecursiveScriptModule,
     device = _choose_device()
     torchsript.to(device)
 
-    img = AICSImage(test_img_path)
+    img = BioImage(test_img_path)
     if "S" in img.dims.order and img.dims.S > img.dims.C:
         input_data = img.get_image_data("SYX")
     else:

--- a/notebooks/export_model.ipynb
+++ b/notebooks/export_model.ipynb
@@ -11,7 +11,6 @@
     "\n",
     "import torch\n",
     "from instanseg.utils.create_bioimageio_model import export_bioimageio\n",
-    "from aicsimageio import AICSImage\n",
     "from instanseg.utils.utils import show_images\n",
     "\n",
     "import os\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,8 +18,9 @@ classifiers = [
 ]
 
 dependencies = [
-    "aicsimageio>=4.11.0",
-    "bioio>=1.1.0",
+    "bioio~=1.1.0",
+    "bioio-ome-tiff~=1.0.1",
+    "bioio-ome-tiff~=1.0.1",
     "colorcet>=3.0.1",
     "einops>=0.7.0",
     "fastremap>=1.14.0",
@@ -44,9 +45,8 @@ test = [
     "genbadge~=1.1.1"
 ]
 full = [
-    "aicsimageio>=4.10.0",
-    "bioimageio.core==0.5.11",
-    "bioimageio.spec==0.4.9",
+    "bioimageio.core~=0.5.11",
+    "bioimageio.spec~=0.4.9",
     "colorcet>=3.0.1",
     "cucim>=23.10.00; platform_system=='Linux'",
     "edt",


### PR DESCRIPTION
Add bioio zarr and tiff readers. Users can add other plugins if they want to read more image types.

Remove AICSImageIO use as it's deprecated.

Add unit test for all image readers.