### PR TITLE
Temporarily move model downloads somewhere else

### DIFF
--- a/instanseg/bioimageio_models/model-index.json
+++ b/instanseg/bioimageio_models/model-index.json
@@ -1,13 +1,13 @@
 [
   {
     "name": "brightfield_nuclei",
-    "url": "https://github.com/instanseg/instanseg/releases/download/v0.1.0/brightfield_nuclei.zip",
+    "url": "https://github.com/alanocallaghan/instanseg/releases/download/v0.1.0/brightfield_nuclei.zip",
     "version": "0.1.0",
     "license": "Apache-2.0"
   },
   {
     "name": "fluorescence_nuclei_and_cells",
-    "url": "https://github.com/instanseg/instanseg/releases/download/v0.1.0/fluorescence_nuclei_and_cells.zip",
+    "url": "https://github.com/alanocallaghan/instanseg/releases/download/v0.1.0/fluorescence_nuclei_and_cells.zip",
     "version": "0.1.0",
     "license": "Apache-2.0"
   }


### PR DESCRIPTION
Unfortunately the qupath instanseg extension takes the first release from this repo, which in this case is a different zip structure than the original releases. Since we can't update the RC3 code, I'm instead moving the downloads for the instanseg main branch to my fork until we release rc4 or 0.6.0 proper, at which point we can happily brick instanseg on rc3.