### PR TITLE
Fix: Add sigmoid activation to pixel classifier output in compute_crops

### DIFF
--- a/instanseg/utils/loss/instanseg_loss.py
+++ b/instanseg/utils/loss/instanseg_loss.py
@@ -212,7 +212,7 @@ def compute_crops( x: torch.Tensor,
     x = feature_engineering(x, c, sigma, window_size //2 , mesh_grid_flat)
 
 
-    x = pixel_classifier(x)  # C*H*W,1
+    x = torch.sigmoid(pixel_classifier(x))  # C*H*W,1
 
     x = x.view(C, 1, window_size, window_size)
 


### PR DESCRIPTION
Added missing sigmoid activation to pixel classifier output in compute_crops() to ensure consistency with forward() method. This ensures mask thresholds are always applied to probability values (0-1 range) rather than raw logits.