### PR TITLE
Fix autodocs and add github action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,29 @@
+on:
+    push:
+      branches:
+        - main
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up python
+        id: setup-python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: Install
+        run: |
+          pip install .[full,test,doc]
+      - name: Build docs
+        run: |
+          sphinx-build docs/ docs/build/html
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        if: github.ref == 'refs/heads/main'
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: docs/build/html

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,8 +4,8 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
 # Add path to code for sphinx.ext.autodoc
-import sys, os
-sys.path.insert(0, os.path.abspath('../instanseg'))
+# import sys, os
+# sys.path.insert(0, os.path.abspath('../instanseg'))
 
 # Both the class’ and the __init__ method’s docstring are concatenated and inserted
 autoclass_content = "both"
@@ -16,22 +16,21 @@ autoclass_content = "both"
 project = 'InstanSeg'
 copyright = "2024, Thibaut Goldsborough, The University of Edinburgh"
 author = "Thibaut Goldsborough"
-release = '0.0.1'
+release = '0.1.0'
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
 extensions = [
-    "sphinx.ext.autodoc",
+    "sphinx.ext.autodoc"
 ]
 
 templates_path = ['_templates']
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
 
-
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
 html_theme = 'sphinx_rtd_theme'
-html_static_path = ['_static']
+# html_static_path = ['_static']

--- a/docs/instanseg.inference_class.rst
+++ b/docs/instanseg.inference_class.rst
@@ -1,0 +1,7 @@
+InstanSeg inference class
+=========================
+
+.. automodule:: instanseg.inference_class
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/instanseg.rst
+++ b/docs/instanseg.rst
@@ -3,12 +3,21 @@ API documentation
 
 This page contains the list of public classes and functions of the InstanSeg package.
 
+
 .. toctree::
    :maxdepth: 4
 
+   instanseg.inference_class
+   instanseg.utils.AI_utils
+   instanseg.utils.augmentation_config
+   instanseg.utils.augmentations
+   instanseg.utils.biological_utils
+   instanseg.utils.data_download
+   instanseg.utils.data_loader
+   instanseg.utils.metrics
+   instanseg.utils.model_loader
+   instanseg.utils.pytorch_utils
+   instanseg.utils.utils
 
-.. automodule:: instanseg
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
+   .. instanseg.utils.create_bioimageio_model
+   .. instanseg.utils.tiling

--- a/docs/instanseg.utils.AI_utils.rst
+++ b/docs/instanseg.utils.AI_utils.rst
@@ -1,0 +1,9 @@
+
+InstanSeg AI utils
+=========================
+
+.. automodule:: instanseg.utils.AI_utils
+   :members:
+   :undoc-members:
+   :show-inheritance:
+

--- a/docs/instanseg.utils.augmentation_config.rst
+++ b/docs/instanseg.utils.augmentation_config.rst
@@ -1,0 +1,9 @@
+
+InstanSeg augmentation_config
+=========================
+
+.. automodule:: instanseg.utils.augmentation_config
+   :members:
+   :undoc-members:
+   :show-inheritance:
+

--- a/docs/instanseg.utils.augmentations.rst
+++ b/docs/instanseg.utils.augmentations.rst
@@ -1,0 +1,9 @@
+
+InstanSeg augmentations
+=========================
+
+.. automodule:: instanseg.utils.augmentations
+   :members:
+   :undoc-members:
+   :show-inheritance:
+

--- a/docs/instanseg.utils.biological_utils.rst
+++ b/docs/instanseg.utils.biological_utils.rst
@@ -1,0 +1,9 @@
+
+InstanSeg biological_utils
+=========================
+
+.. automodule:: instanseg.utils.biological_utils
+   :members:
+   :undoc-members:
+   :show-inheritance:
+

--- a/docs/instanseg.utils.create_bioimageio_model.rst
+++ b/docs/instanseg.utils.create_bioimageio_model.rst
@@ -1,0 +1,9 @@
+
+InstanSeg create_bioimageio_model
+=========================
+
+.. automodule:: instanseg.utils.create_bioimageio_model
+   :members:
+   :undoc-members:
+   :show-inheritance:
+

--- a/docs/instanseg.utils.data_download.rst
+++ b/docs/instanseg.utils.data_download.rst
@@ -1,0 +1,9 @@
+
+InstanSeg data_download
+=========================
+
+.. automodule:: instanseg.utils.data_download
+   :members:
+   :undoc-members:
+   :show-inheritance:
+

--- a/docs/instanseg.utils.data_loader.rst
+++ b/docs/instanseg.utils.data_loader.rst
@@ -1,0 +1,9 @@
+
+InstanSeg data_loader
+=========================
+
+.. automodule:: instanseg.utils.data_loader
+   :members:
+   :undoc-members:
+   :show-inheritance:
+

--- a/docs/instanseg.utils.metrics.rst
+++ b/docs/instanseg.utils.metrics.rst
@@ -1,0 +1,9 @@
+
+InstanSeg metrics
+=========================
+
+.. automodule:: instanseg.utils.metrics
+   :members:
+   :undoc-members:
+   :show-inheritance:
+

--- a/docs/instanseg.utils.model_loader.rst
+++ b/docs/instanseg.utils.model_loader.rst
@@ -1,0 +1,9 @@
+
+InstanSeg model_loader
+=========================
+
+.. automodule:: instanseg.utils.model_loader
+   :members:
+   :undoc-members:
+   :show-inheritance:
+

--- a/docs/instanseg.utils.pytorch_utils.rst
+++ b/docs/instanseg.utils.pytorch_utils.rst
@@ -1,0 +1,9 @@
+
+InstanSeg pytorch_utils
+=========================
+
+.. automodule:: instanseg.utils.pytorch_utils
+   :members:
+   :undoc-members:
+   :show-inheritance:
+

--- a/docs/instanseg.utils.tiling.rst
+++ b/docs/instanseg.utils.tiling.rst
@@ -1,0 +1,9 @@
+
+InstanSeg tiling
+=========================
+
+.. automodule:: instanseg.utils.tiling
+   :members:
+   :undoc-members:
+   :show-inheritance:
+

--- a/docs/instanseg.utils.utils.rst
+++ b/docs/instanseg.utils.utils.rst
@@ -1,0 +1,9 @@
+
+InstanSeg utils
+=========================
+
+.. automodule:: instanseg.utils.utils
+   :members:
+   :undoc-members:
+   :show-inheritance:
+


### PR DESCRIPTION
Ideally we would document any non-documented functions, or remove them from the public API, and also write some long-form documentation such as notebooks