### PR TITLE
constrain requires-python lower bound to >=3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 ]
 description = "Package for instanseg-torch PyPi"
 readme = "README.md"
-requires-python = ">=3.9, <3.12"
+requires-python = ">=3.10, <3.12"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: Apache Software License",


### PR DESCRIPTION
When resolving dependencies using uv, the following error is raised:

Creating virtual environment at: .venv
  × No solution found when resolving dependencies:
  ╰─▶ Because the requested Python version (>=3.9, <3.12) does not satisfy Python>=3.10 and
      bioio>=1.5.0 depends on Python>=3.10, we can conclude that bioio>=1.5.0 cannot be used.
      And because only the following versions of bioio are available:
          bioio<=1.5.0
          bioio==1.5.1
          bioio==1.5.2
      we can conclude that bioio>=1.5.0 cannot be used.
      And because your project depends on bioio>=1.5.0 and your project requires
      instanseg-torch[test], we can conclude that your projects's requirements are
      unsatisfiable.

Constraining the lower bound of requires-python to >=3.10 resolves this issue.