### PR TITLE
Alter features code to return similar ndarrays for cell, nucleus, cytoplasm

### DIFF
--- a/instanseg/utils/biological_utils.py
+++ b/instanseg/utils/biological_utils.py
@@ -215,17 +215,17 @@ def resolve_cell_and_nucleus_boundaries(lab: torch.Tensor, allow_unnucleated_cel
     return torch.stack((nuclei_labels, cell_labels)).unsqueeze(0)
 
 
-def get_mean_object_features(image: torch.Tensor, label: torch.Tensor, num_classes: int = -1) -> torch.Tensor:
+def get_mean_object_features(image: torch.Tensor, label: torch.Tensor, droplabels: bool = True) -> torch.Tensor:
     # image is C,H,W
     # label is H,W
+    # droplabels: drop unused labels (ie remap to contiguous values)
     # returns a tensor of size N,C for N objects and C channels
 
     if label.max() == 0:
         return torch.tensor([])
     label = label.squeeze()
     
-    ## use the standard torch onehot implementation to avoid dropping unused classes
-    sparse_onehot = torch.nn.functional.one_hot(label.long(), num_classes=num_classes).flatten(0, 1).transpose(0, 1).to_sparse_coo().float()
+    sparse_onehot = torch_sparse_onehot(label, flatten=True, remap=droplabels)[0]
     out = torch.mm(sparse_onehot, image.flatten(1).T)  # object features
     sums = torch.sparse.sum(sparse_onehot, dim=(1,)).to_dense()  # object areas
     out = out / sums[None].T  # mean object features
@@ -237,11 +237,11 @@ def get_features_by_location(input_tensor: torch.Tensor, lab: torch.Tensor, to_n
     # lab is 1,2,H,W where the first channel is nuclei and the second is whole cell
     ## specify number of classes to ensure cell i matches nucleus i matches cytoplasm i
     num_classes = int(torch.max(lab).item() + 1)
-    X_cell = get_mean_object_features(input_tensor, lab[0, 1], num_classes)
-    X_nuclei = get_mean_object_features(input_tensor, lab[0, 0], num_classes)
+    X_cell = get_mean_object_features(input_tensor, lab[0, 1], droplabels=False)
+    X_nuclei = get_mean_object_features(input_tensor, lab[0, 0], droplabels=False)
 
     cytoplasm_lab = (lab[0, 0] == 0).float() * lab[0, 1]
-    X_cytoplasm = get_mean_object_features(input_tensor, cytoplasm_lab, num_classes)
+    X_cytoplasm = get_mean_object_features(input_tensor, cytoplasm_lab, droplabels=False)
 
 
     if to_numpy:

--- a/instanseg/utils/biological_utils.py
+++ b/instanseg/utils/biological_utils.py
@@ -215,17 +215,17 @@ def resolve_cell_and_nucleus_boundaries(lab: torch.Tensor, allow_unnucleated_cel
     return torch.stack((nuclei_labels, cell_labels)).unsqueeze(0)
 
 
-def get_mean_object_features(image: torch.Tensor, label: torch.Tensor, droplabels: bool = True) -> torch.Tensor:
+def get_mean_object_features(image: torch.Tensor, label: torch.Tensor, max_label: int = None) -> torch.Tensor:
     # image is C,H,W
     # label is H,W
-    # droplabels: drop unused labels (ie remap to contiguous values)
+    # max_label: highest label, useful if calculating mean features for different compartments
     # returns a tensor of size N,C for N objects and C channels
 
     if label.max() == 0:
         return torch.tensor([])
     label = label.squeeze()
     
-    sparse_onehot = torch_sparse_onehot(label, flatten=True, remap=droplabels)[0]
+    sparse_onehot = torch_sparse_onehot(label, flatten=True, max=max_label)[0]
     out = torch.mm(sparse_onehot, image.flatten(1).T)  # object features
     sums = torch.sparse.sum(sparse_onehot, dim=(1,)).to_dense()  # object areas
     out = out / sums[None].T  # mean object features
@@ -236,13 +236,12 @@ def get_features_by_location(input_tensor: torch.Tensor, lab: torch.Tensor, to_n
     # input tensor is C,H,W
     # lab is 1,2,H,W where the first channel is nuclei and the second is whole cell
     ## specify number of classes to ensure cell i matches nucleus i matches cytoplasm i
-    num_classes = int(torch.max(lab).item() + 1)
-    X_cell = get_mean_object_features(input_tensor, lab[0, 1], droplabels=False)
-    X_nuclei = get_mean_object_features(input_tensor, lab[0, 0], droplabels=False)
+    num_classes = int(torch.max(lab).item())
+    X_cell = get_mean_object_features(input_tensor, lab[0, 1], max_label=num_classes)
+    X_nuclei = get_mean_object_features(input_tensor, lab[0, 0], max_label=num_classes)
 
     cytoplasm_lab = (lab[0, 0] == 0).float() * lab[0, 1]
-    X_cytoplasm = get_mean_object_features(input_tensor, cytoplasm_lab, droplabels=False)
-
+    X_cytoplasm = get_mean_object_features(input_tensor, cytoplasm_lab, max_label=num_classes)
 
     if to_numpy:
         X_cell = X_cell.cpu().numpy()

--- a/instanseg/utils/biological_utils.py
+++ b/instanseg/utils/biological_utils.py
@@ -215,7 +215,7 @@ def resolve_cell_and_nucleus_boundaries(lab: torch.Tensor, allow_unnucleated_cel
     return torch.stack((nuclei_labels, cell_labels)).unsqueeze(0)
 
 
-def get_mean_object_features(image: torch.Tensor, label: torch.Tensor, max_label: int = None) -> torch.Tensor:
+def get_mean_object_features(image: torch.Tensor, label: torch.Tensor, max_label: int = -1) -> torch.Tensor:
     # image is C,H,W
     # label is H,W
     # max_label: highest label, useful if calculating mean features for different compartments

--- a/instanseg/utils/biological_utils.py
+++ b/instanseg/utils/biological_utils.py
@@ -215,7 +215,7 @@ def resolve_cell_and_nucleus_boundaries(lab: torch.Tensor, allow_unnucleated_cel
     return torch.stack((nuclei_labels, cell_labels)).unsqueeze(0)
 
 
-def get_mean_object_features(image: torch.Tensor, label: torch.Tensor) -> torch.Tensor:
+def get_mean_object_features(image: torch.Tensor, label: torch.Tensor, num_classes: int = -1) -> torch.Tensor:
     # image is C,H,W
     # label is H,W
     # returns a tensor of size N,C for N objects and C channels
@@ -224,7 +224,8 @@ def get_mean_object_features(image: torch.Tensor, label: torch.Tensor) -> torch.
         return torch.tensor([])
     label = label.squeeze()
     
-    sparse_onehot = torch_sparse_onehot(label, flatten=True)[0]
+    ## use the standard torch onehot implementation to avoid dropping unused classes
+    sparse_onehot = torch.nn.functional.one_hot(label.long(), num_classes=num_classes+1).flatten(0, 1).transpose(0, 1).to_sparse_coo().float()
     out = torch.mm(sparse_onehot, image.flatten(1).T)  # object features
     sums = torch.sparse.sum(sparse_onehot, dim=(1,)).to_dense()  # object areas
     out = out / sums[None].T  # mean object features
@@ -234,13 +235,13 @@ def get_mean_object_features(image: torch.Tensor, label: torch.Tensor) -> torch.
 def get_features_by_location(input_tensor: torch.Tensor, lab: torch.Tensor, to_numpy: bool = True) -> tuple:
     # input tensor is C,H,W
     # lab is 1,2,H,W where the first channel is nuclei and the second is whole cell
-
-    X_cell = get_mean_object_features(input_tensor, lab[0, 1])
-    X_nuclei = get_mean_object_features(input_tensor, lab[0, 0])
+    ## specify number of classes to ensure cell i matches nucleus i matches cytoplasm i
+    num_classes = int(torch.max(lab).item() + 1)
+    X_cell = get_mean_object_features(input_tensor, lab[0, 1], num_classes)
+    X_nuclei = get_mean_object_features(input_tensor, lab[0, 0], num_classes)
 
     cytoplasm_lab = (lab[0, 0] == 0).float() * lab[0, 1]
-    X_nuclei = get_mean_object_features(input_tensor, lab[0, 0])
-    X_cytoplasm = get_mean_object_features(input_tensor, cytoplasm_lab)
+    X_cytoplasm = get_mean_object_features(input_tensor, cytoplasm_lab, num_classes)
 
 
     if to_numpy:

--- a/instanseg/utils/biological_utils.py
+++ b/instanseg/utils/biological_utils.py
@@ -225,7 +225,7 @@ def get_mean_object_features(image: torch.Tensor, label: torch.Tensor, num_class
     label = label.squeeze()
     
     ## use the standard torch onehot implementation to avoid dropping unused classes
-    sparse_onehot = torch.nn.functional.one_hot(label.long(), num_classes=num_classes+1).flatten(0, 1).transpose(0, 1).to_sparse_coo().float()
+    sparse_onehot = torch.nn.functional.one_hot(label.long(), num_classes=num_classes).flatten(0, 1).transpose(0, 1).to_sparse_coo().float()
     out = torch.mm(sparse_onehot, image.flatten(1).T)  # object features
     sums = torch.sparse.sum(sparse_onehot, dim=(1,)).to_dense()  # object areas
     out = out / sums[None].T  # mean object features

--- a/instanseg/utils/pytorch_utils.py
+++ b/instanseg/utils/pytorch_utils.py
@@ -263,12 +263,13 @@ def fast_dual_iou(onehot1: torch.Tensor, onehot2: torch.Tensor) -> torch.Tensor:
     return (intersection / union)[:C1, :C2]
 
 
-def torch_sparse_onehot(x: torch.Tensor, flatten: bool = False, remap: bool = True) -> Tuple[torch.Tensor, torch.Tensor]:
+def torch_sparse_onehot(x: torch.Tensor, flatten: bool = False, max: int = -1) -> Tuple[torch.Tensor, torch.Tensor]:
     # x is a labeled image of shape _,_,H,W returns a sparse tensor of shape C,H,W
     unique_values = torch.unique(x, sorted=True)
-    if remap:
+    if max == -1:
         x = torch_fastremap(x)
-
+        max = x.max().int().item()
+        
     H, W = x.shape[-2], x.shape[-1]
 
 
@@ -281,7 +282,7 @@ def torch_sparse_onehot(x: torch.Tensor, flatten: bool = False, remap: bool = Tr
         x = x.reshape(H * W)
         xxyy = torch.nonzero(x > 0).squeeze(1)
         zz = x[xxyy] - 1
-        C = x.max().int().item()
+        C = max
 
        # print(C, H, W, type(C), type(H), type(W))
         sparse_onehot = torch.sparse_coo_tensor(torch.stack((zz, xxyy)).long(), (torch.ones_like(xxyy).float()),

--- a/instanseg/utils/pytorch_utils.py
+++ b/instanseg/utils/pytorch_utils.py
@@ -263,10 +263,11 @@ def fast_dual_iou(onehot1: torch.Tensor, onehot2: torch.Tensor) -> torch.Tensor:
     return (intersection / union)[:C1, :C2]
 
 
-def torch_sparse_onehot(x: torch.Tensor, flatten: bool = False) -> Tuple[torch.Tensor, torch.Tensor]:
+def torch_sparse_onehot(x: torch.Tensor, flatten: bool = False, remap: bool = True) -> Tuple[torch.Tensor, torch.Tensor]:
     # x is a labeled image of shape _,_,H,W returns a sparse tensor of shape C,H,W
     unique_values = torch.unique(x, sorted=True)
-    x = torch_fastremap(x)
+    if remap:
+        x = torch_fastremap(x)
 
     H, W = x.shape[-2], x.shape[-1]
 


### PR DESCRIPTION
Previously, if a cell had no cytoplasm (i.e., if nucleus mask == cell mask) then it would be dropped from the corresponding matrix of cytoplasmic features. This aims to ensure that the 3 matrices returned at the end are of the same dimensionality, so that it is easier to match features across cells.

I've done my best to ensure this works, but I'm not super confident in my torch-ing. I can add unit tests if you like