### PR TITLE
Don't move tensors back to CPU

### DIFF
--- a/instanseg/inference_class.py
+++ b/instanseg/inference_class.py
@@ -496,9 +496,9 @@ class InstanSeg():
                 image = interpolate(image, size=original_shape[-2:], mode="bilinear")
 
         if return_image_tensor:
-            return instances.cpu(), image.cpu()
+            return instances, image
         else:
-            return instances.cpu()
+            return instances
 
     def eval_medium_image(self,
                           image: torch.Tensor, 
@@ -598,9 +598,9 @@ class InstanSeg():
         image = _to_ndim(image, original_ndim)
 
         if return_image_tensor:
-            return instances.cpu(), image.cpu()
+            return instances, image
         else:
-            return instances.cpu()
+            return instances
 
         
     def eval_whole_slide_image(self,


### PR DESCRIPTION
This makes it slightly more cumbersome for users, who would have to do something like

```python
mod = InstanSeg()
lab, im2 = mod.eval(im)
## now needed
lab, im2 = [x.cpu() for x in [lab, im2]]
```

An alternative is to add a flag that defaults to `True` to return tensors on the CPU, retaining current behaviour but switching to this PRs behaviour if requested.

Resolve #143 